### PR TITLE
fix: remove erroneous updated_at trigger for agents table

### DIFF
--- a/supabase/migrations/20240320000000_initial_schema.sql
+++ b/supabase/migrations/20240320000000_initial_schema.sql
@@ -198,11 +198,6 @@ CREATE TRIGGER update_users_updated_at
     FOR EACH ROW
     EXECUTE FUNCTION update_updated_at_column();
 
-CREATE TRIGGER update_agents_updated_at
-    BEFORE UPDATE ON agents
-    FOR EACH ROW
-    EXECUTE FUNCTION update_updated_at_column();
-
 CREATE TRIGGER update_offers_updated_at
     BEFORE UPDATE ON offers
     FOR EACH ROW


### PR DESCRIPTION
Agents table does not have an udpated_at column so having a trigger to change updated_at doesn't make sense.

I've already run a SQL query on the test and prod databases to remove the trigger.

We're changing this initial migration file in case we deploy a new database in the future, it won't have the trigger by default.